### PR TITLE
Webcrawl Runtime

### DIFF
--- a/PurduePrep/main.py
+++ b/PurduePrep/main.py
@@ -35,13 +35,14 @@ def main(user_input):
     for url, score in sorted_relevant_urls:
         relevant_character_indices = score[1]
         pdf_text, _ = get_content_from_pdf_link(url)
-        page_content = Page(url, pdf_text, relevant_character_indices)
+        if pdf_text:
+            page_content = Page(url, pdf_text, relevant_character_indices)
 
-        # Web scraper ---(extracted text)---> Question ID
-        # Step 7: Use NLP to identify questions
-        page_questions = find_questions(page_content)
-        for question in page_questions:
-            questions.append((question, url))
+            # Web scraper ---(extracted text)---> Question ID
+            # Step 7: Use NLP to identify questions
+            page_questions = find_questions(page_content)
+            for question in page_questions:
+                questions.append((question, url))
 
         # Question ID ---(question objects)---> Relevance checker
         # Step 8: Question objects go to relevance checker to be evaluated for content

--- a/PurduePrep/webcrawl/crawler.py
+++ b/PurduePrep/webcrawl/crawler.py
@@ -4,30 +4,28 @@ import time
 
 CRAWL_DEPTH = 2
 
-# Input from Emma
+#keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
 #keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
 #keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
-keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
+#keywords = ['binary', 'tree', 'bubble sort', 'sort', 'complexity']
+keywords = ['discrete', 'math', 'mathematics']
+
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
 start_time = time.time()
 # Gather relevant websites from query
 websites_list, all_page_scores = init_gather_websites(search_query)
+sorted_relevant_urls = crawl_websites(search_query, websites_list, CRAWL_DEPTH, all_page_scores)
+print(sorted_relevant_urls)
 
-for web_pairs in websites_list:
-    crawl_time = time.time()
+crawl_time = time.time()
+print(f"Total time to gather relevant sites: {crawl_time - start_time} seconds")
 
-    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
+# Extract page content
+for url, score in sorted_relevant_urls:
+    relevant_character_indices = score[1]
+    pdf_text, _ = get_content_from_pdf_link(url)
+    page_content = Page(url, pdf_text, relevant_character_indices)
 
-    end_time = time.time()
-    print(f"Total time to crawl pair: {end_time - crawl_time} seconds")
-    print('')
-    
-    print(sorted_relevant_urls)
-
-    # Extract page content
-    for url, score in sorted_relevant_urls:
-        relevant_character_indices = score[1]
-        pdf_text, _ = get_content_from_pdf_link(url)
-        page_content = Page(url, pdf_text, relevant_character_indices)
-
+end_time = time.time()
+print(f"Total time to pull web content: {end_time - crawl_time} seconds")

--- a/PurduePrep/webcrawl/crawler.py
+++ b/PurduePrep/webcrawl/crawler.py
@@ -7,8 +7,8 @@ CRAWL_DEPTH = 2
 #keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
 #keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
 #keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
-#keywords = ['binary', 'tree', 'bubble sort', 'sort', 'complexity']
-keywords = ['discrete', 'math', 'mathematics']
+keywords = ['binary', 'tree', 'bubble sort', 'sort', 'complexity']
+#keywords = ['discrete', 'math', 'mathematics']
 
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
@@ -25,7 +25,8 @@ print(f"Total time to gather relevant sites: {crawl_time - start_time} seconds")
 for url, score in sorted_relevant_urls:
     relevant_character_indices = score[1]
     pdf_text, _ = get_content_from_pdf_link(url)
-    page_content = Page(url, pdf_text, relevant_character_indices)
+    if pdf_text:
+        page_content = Page(url, pdf_text, relevant_character_indices)
 
 end_time = time.time()
 print(f"Total time to pull web content: {end_time - crawl_time} seconds")

--- a/PurduePrep/webcrawl/crawler.py
+++ b/PurduePrep/webcrawl/crawler.py
@@ -1,8 +1,3 @@
-import requests
-# from webcrawl.webcrawl_functions import get_content_from_pdf_link
-# from welcrawl.webcrawl_functions import get_content_from_pdf_link, get_websites, init_gather_websites, crawl
-# from webcrawl.page import Page
-
 from PurduePrep.webcrawl.webcrawl_functions import get_content_from_pdf_link, init_gather_websites, crawl_websites
 from PurduePrep.webcrawl.page import Page
 import time
@@ -11,22 +6,24 @@ CRAWL_DEPTH = 2
 
 # Input from Emma
 #keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
+#keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
 keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
 start_time = time.time()
 # Gather relevant websites from query
 websites_list, all_page_scores = init_gather_websites(search_query)
-sorted_relevant_urls = crawl_websites(search_query, websites_list, CRAWL_DEPTH, all_page_scores)
 
-crawl_time = time.time()
-print(f"Total time to gather relevant sites: {crawl_time - start_time} seconds")
+for web_pairs in websites_list:
+    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
+    print(sorted_relevant_urls)
+    crawl_time = time.time()
 
-# Extract page content
-for url, score in sorted_relevant_urls:
-    relevant_character_indices = score[1]
-    pdf_text, _ = get_content_from_pdf_link(url)
-    page_content = Page(url, pdf_text, relevant_character_indices)
+    # Extract page content
+    for url, score in sorted_relevant_urls:
+        relevant_character_indices = score[1]
+        pdf_text, _ = get_content_from_pdf_link(url)
+        page_content = Page(url, pdf_text, relevant_character_indices)
 
-end_time = time.time()
-print(f"Total time to pull web content: {end_time - crawl_time} seconds")
+    end_time = time.time()
+    print(f"Total time to crawl pair: {end_time - crawl_time} seconds")

--- a/PurduePrep/webcrawl/crawler.py
+++ b/PurduePrep/webcrawl/crawler.py
@@ -15,9 +15,15 @@ start_time = time.time()
 websites_list, all_page_scores = init_gather_websites(search_query)
 
 for web_pairs in websites_list:
-    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
-    print(sorted_relevant_urls)
     crawl_time = time.time()
+
+    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
+
+    end_time = time.time()
+    print(f"Total time to crawl pair: {end_time - crawl_time} seconds")
+    print('')
+    
+    print(sorted_relevant_urls)
 
     # Extract page content
     for url, score in sorted_relevant_urls:
@@ -25,5 +31,3 @@ for web_pairs in websites_list:
         pdf_text, _ = get_content_from_pdf_link(url)
         page_content = Page(url, pdf_text, relevant_character_indices)
 
-    end_time = time.time()
-    print(f"Total time to crawl pair: {end_time - crawl_time} seconds")

--- a/PurduePrep/webcrawl/webcrawl_functions.py
+++ b/PurduePrep/webcrawl/webcrawl_functions.py
@@ -30,7 +30,6 @@ def get_websites(search_query):
         for link_number in range(num_links):
             websites_list.append(results['items'][link_number]['link'])
     else:
-        #print("No results found.")
         websites_list.append("-1")
     
     return websites_list
@@ -39,38 +38,14 @@ def open_url(url_to_scrape):
     try:
         url_content = requests.get(url=url_to_scrape, headers={'User-Agent': "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"}, timeout=1.5)
         if not url_content.ok:
-            #print("Could not read content at: " + url_to_scrape)
             url_content = -1
         return url_content
     
     except requests.exceptions.Timeout:
-        #print(f"Timeout occurred while trying to retrieve {url_to_scrape}. Skipping.")
         return -1 # Skip this URL if it times out
     
     except requests.RequestException as e:
-        #print(f"Failed to retrieve {url_to_scrape}: {e}")
         return  -1 # Handle other request exceptions
-
-def get_content_from_pdf_link(url):
-    title_page_multiplier = 1
-    pdf_content = open_url(url)
-    
-    if pdf_content == -1:
-        return False, title_page_multiplier
-    
-    pdf_reader = PyPDF2.PdfReader(BytesIO(pdf_content.content))
-    pdf_text = ""
-
-    if len(pdf_reader.pages) > 20:
-        return False, title_page_multiplier
-
-    if ("exam" or "Exam" or "midterm" or "Midterm" or "final" or "Final") in pdf_reader.pages[0].extract_text():
-        title_page_multiplier = 1.5
-    
-    for page_num in range(len(pdf_reader.pages)):
-        pdf_text += pdf_reader.pages[page_num].extract_text()
-    
-    return pdf_text, title_page_multiplier
 
 def get_webcrawl_functions_path():
     current_dir = Path(__file__).resolve()
@@ -100,8 +75,49 @@ def init_gather_websites(keywords_str):
     all_page_scores = defaultdict(int)
     return websites_list, all_page_scores
 
-def crawl(url, depth, keywords, visited = None, page_scores = None, domain_visit_count = None, blacklist = None, whitelist = None):
+def update_lists(url, blacklist, visited, domain_visit_count):
+    domain = urlparse(url).netloc
 
+    organization_match = re.search(r'\b(?:[a-zA-Z0-9-]+)\.(edu|ac|com|net|gov)\b', domain)
+    org_name = organization_match.group(0)
+
+    if domain_visit_count[domain] >= 150 and org_name not in blacklist:
+        blacklist.append(org_name)
+    
+    visited.add(url)
+    return blacklist, visited, domain
+
+def get_content_from_pdf_link(url):
+    title_page_multiplier = 1
+    pdf_content = open_url(url)
+    
+    if pdf_content == -1:
+        return False, title_page_multiplier
+    
+    pdf_reader = PyPDF2.PdfReader(BytesIO(pdf_content.content))
+    pdf_text = ""
+
+    if len(pdf_reader.pages) > 20:
+        return False, title_page_multiplier
+
+    if ("exam" or "Exam" or "midterm" or "Midterm" or "final" or "Final") in pdf_reader.pages[0].extract_text():
+        title_page_multiplier = 1.5
+    
+    for page_num in range(len(pdf_reader.pages)):
+        pdf_text += pdf_reader.pages[page_num].extract_text()
+
+    return pdf_text, title_page_multiplier
+
+def search_pdf(url):
+    #Open PDF and get its text
+    pdf_text, title_page_multiplier = get_content_from_pdf_link(url)
+    if pdf_text:
+        score, pattern_indices = check_if_exam(pdf_text)
+        page_score = (score *title_page_multiplier, pattern_indices)
+        return page_score
+    return (0,[])
+
+def initialize_crawl_defaults(visited=None, page_scores=None, domain_visit_count=None, blacklist=None, whitelist=None):
     if visited is None:
         visited = set()
     if page_scores is None:
@@ -109,23 +125,30 @@ def crawl(url, depth, keywords, visited = None, page_scores = None, domain_visit
     if domain_visit_count is None:
         domain_visit_count = defaultdict(int)
     if blacklist is None:
-        blacklist = ['lec','Lecture', 'Syllabus', 'syllabus', 'youtube', 'Youtube']
+        blacklist = ['lec', 'Lecture', 'Syllabus', 'syllabus', 'youtube', 'Youtube']
     if whitelist is None:
         whitelist = ['Mid', 'mid', 'final', 'exam', 'Exam']
+    
+    return visited, page_scores, domain_visit_count, blacklist, whitelist
+
+def get_page_links(url):
+    http_request_response = open_url(url)
+    if http_request_response == -1:
+        return
+    soup = BeautifulSoup(http_request_response.text, 'html.parser')
+    links = soup.find_all('a', href=True)
+    return links
+
+def crawl(url, depth, keywords, visited = None, page_scores = None, domain_visit_count = None, blacklist = None, whitelist = None):
+    
+    visited, page_scores, domain_visit_count, blacklist, whitelist = initialize_crawl_defaults(
+        visited, page_scores, domain_visit_count, blacklist, whitelist)
+    
     if depth == 0 or url in visited:
         return
-
-    domain = urlparse(url).netloc
-    visited.add(url)
+    
     print(f"Crawling: {url}")
-
-    organization_match = re.search(r'\b(?:[a-zA-Z0-9-]+)\.(edu|ac|com|net|gov)\b', domain)  # Match .edu or .ac domains
-    org_name = organization_match.group(0)
-
-    if domain_visit_count[domain] >= 150 and org_name not in blacklist:
-        blacklist.append(org_name)
-        return
-
+    blacklist, visited, domain = update_lists(url, blacklist, visited, domain_visit_count)
     if any(pattern in url.lower() for pattern in blacklist):
         if not any(pattern in url.lower() for pattern in whitelist):
             print(f"Skipping URL (blacklisted pattern): {url}")
@@ -133,24 +156,11 @@ def crawl(url, depth, keywords, visited = None, page_scores = None, domain_visit
     
     ## Fetch PDF content
     if url.lower().endswith('.pdf'):
-        #Open PDF and get its text
-        pdf_text, title_page_multiplier = get_content_from_pdf_link(url)
-        if pdf_text:
-            score, pattern_indices = check_if_exam(pdf_text)
-            page_scores[url] = (score *title_page_multiplier, pattern_indices)
+        page_scores[url] = search_pdf(url)
             
-    ## If not PDF, keep looking for a DARN PDF
+    ## If not PDF, continue crawl
     else:
-        http_request_response = open_url(url)
-        if http_request_response == -1:
-            return
-        
-        # Parse html
-        soup = BeautifulSoup(http_request_response.text, 'html.parser')
-        page_text = soup.get_text()
-        
-        # Find all the links on the page and crawl them
-        links = soup.find_all('a', href=True)
+        links = get_page_links(url)
         for link in links:
             next_url = urljoin(url, link['href'])
             if next_url not in visited and re.match(r'^https?://', next_url):

--- a/tests/test_crawl_scrape.py
+++ b/tests/test_crawl_scrape.py
@@ -23,9 +23,10 @@ print(sorted_relevant_urls)
 questions = []
 for url, score in sorted_relevant_urls:
     pdf_text, _ = get_content_from_pdf_link(url)
-    page_content = Page(url, pdf_text, score[1])
-    start_nlp_time = time.time()
-    questions.extend(find_questions(page_content))
+    if pdf_text:
+        page_content = Page(url, pdf_text, score[1])
+        start_nlp_time = time.time()
+        questions.extend(find_questions(page_content))
 
 for question in questions:
     print(question)

--- a/tests/test_crawl_scrape.py
+++ b/tests/test_crawl_scrape.py
@@ -6,9 +6,9 @@ import time
 CRAWL_DEPTH = 2
 
 # Input from Emma
-#keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
+keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
 #keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
-keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
+#keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
 
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
@@ -16,16 +16,12 @@ start_time = time.time()
 websites_list, all_page_scores = init_gather_websites(search_query)
 
 for web_pairs in websites_list:
-    print(f'crawling from roots {web_pairs}')
     sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
-    print('finished crawl')
-    crawl_time = time.time()
     
     # Extract page content 
     questions = []
     for url, score in sorted_relevant_urls:
         pdf_text, _ = get_content_from_pdf_link(url)
         page_content = Page(url, pdf_text, score[1])
+        start_nlp_time = time.time()
         questions.extend(find_questions(page_content))
-
-    print(questions)

--- a/tests/test_crawl_scrape.py
+++ b/tests/test_crawl_scrape.py
@@ -1,21 +1,31 @@
 from PurduePrep.webcrawl.webcrawl_functions import get_content_from_pdf_link, init_gather_websites, crawl_websites
 from PurduePrep.webcrawl.page import Page
-from PurduePrep.webcrawl.crawler import crawl_websites
 from PurduePrep.scrape.find_questions import find_questions
+import time
 
 CRAWL_DEPTH = 2
 
-keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
+# Input from Emma
+#keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
+#keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
+keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
+
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
+start_time = time.time()
 websites_list, all_page_scores = init_gather_websites(search_query)
-sorted_relevant_urls = crawl_websites(search_query, websites_list, CRAWL_DEPTH, all_page_scores)
 
-# Extract page content
-questions = []
-for url, score in sorted_relevant_urls:
-    pdf_text, _ = get_content_from_pdf_link(url)
-    page_content = Page(url, pdf_text, score[1])
-    questions.extend(find_questions(page_content))
+for web_pairs in websites_list:
+    print(f'crawling from roots {web_pairs}')
+    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
+    print('finished crawl')
+    crawl_time = time.time()
+    
+    # Extract page content 
+    questions = []
+    for url, score in sorted_relevant_urls:
+        pdf_text, _ = get_content_from_pdf_link(url)
+        page_content = Page(url, pdf_text, score[1])
+        questions.extend(find_questions(page_content))
 
-print(questions)
+    print(questions)

--- a/tests/test_crawl_scrape.py
+++ b/tests/test_crawl_scrape.py
@@ -9,19 +9,24 @@ CRAWL_DEPTH = 2
 keywords = ['cryptography', 'key', 'decryption', 'algorithm', 'encryption', 'secret', 'used', 'ciphertext', 'classical', 'plaintext']
 #keywords = ['vector', 'row space', 'matrix', 'basis', 'diagonalizable']
 #keywords = ['derivative', 'integral', 'integrate', 'chain', 'differentiate']
+#keywords = ['binary', 'tree', 'bubble sort', 'sort', 'complexity']
 
 search_query = f"{' '.join(keywords)} past exam midterm final site:.edu"
 
 start_time = time.time()
 websites_list, all_page_scores = init_gather_websites(search_query)
+sorted_relevant_urls = crawl_websites(search_query, websites_list, CRAWL_DEPTH, all_page_scores)
+print('')
+print(sorted_relevant_urls)
 
-for web_pairs in websites_list:
-    sorted_relevant_urls = crawl_websites(search_query, web_pairs, CRAWL_DEPTH, all_page_scores)
-    
-    # Extract page content 
-    questions = []
-    for url, score in sorted_relevant_urls:
-        pdf_text, _ = get_content_from_pdf_link(url)
-        page_content = Page(url, pdf_text, score[1])
-        start_nlp_time = time.time()
-        questions.extend(find_questions(page_content))
+# Extract page content 
+questions = []
+for url, score in sorted_relevant_urls:
+    pdf_text, _ = get_content_from_pdf_link(url)
+    page_content = Page(url, pdf_text, score[1])
+    start_nlp_time = time.time()
+    questions.extend(find_questions(page_content))
+
+for question in questions:
+    print(question)
+    print("\n")


### PR DESCRIPTION
## CHANGE TYPE 

[  ] New Feature 

[ X ] Feature Update 

[  ] Bug Fix 

## GOAL 
Reduce runtime and clean up webcrawl code.


## DETAILED DESCRIPTION 
- Limits number of searches on a given domain to 150 searches... Will then skip the domain afterwards
- Created a whitelist so that it can skip entire domains but then stop when it sees keywords in the url (Exam, midterm, final, etc)
- page_content.body was returning a bool instead of string when text couldn't be retrieved, creating a TypeError in the NLP code. Fixed this by creating a check before entering the NLP code.
- cleaned up webcrawl code
- shorter timeout time per http request


There are still some other cases where the webcrawler is painfully slow but that's for another pull request.

## REQUESTING SPECIFIC ATTENTION ON 
does it run? Are there any cases where its still super slow
 

## REQUESTING REVIEW BY: 

[X] Josh 

[  ] Seth 

[X] Emma 
